### PR TITLE
Adding directory-named-webpack-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4362,6 +4362,15 @@
         "path-type": "^3.0.0"
       }
     },
+    "directory-named-webpack-plugin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/directory-named-webpack-plugin/-/directory-named-webpack-plugin-4.0.1.tgz",
+      "integrity": "sha512-cULe7U64O9NM+O+L9gfcVKPo/A0pNEntsXTpuRHoCFMYE5pV9XQrJI9mJ8bgo0WKPmKPw/kozXfRolNNFJICCA==",
+      "requires": {
+        "enhanced-resolve": "^4.0.0",
+        "object-assign": "^4.1.0"
+      }
+    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
+    "directory-named-webpack-plugin": "^4.0.1",
     "konva": "^5.0.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
Adding `directory-named-webpack-plugin`. From now on, when importing files you don't have to specify the filename if it matches the folder name.

Example: instead of
```js
import ChipsContainer from "../ChipsContainer/ChipsContainer";
```
you can do
```js
import ChipsContainer from "../ChipsContainer";
```
